### PR TITLE
Add styler option

### DIFF
--- a/spec/column_spec.cr
+++ b/spec/column_spec.cr
@@ -7,6 +7,7 @@ describe Tablo::Column do
     align_header: Tablo::Justify::Left,
     align_body: Tablo::Justify::Left,
     formatter: ->(n : Tablo::CellType) { "%.2f" % n.as(Int32) },
+    styler: ->(n : Tablo::CellType) { n.to_s },
     extractor: ->(n : Array(Tablo::CellType)) { n[0].as(Tablo::CellType) })
 
   describe "#initialize" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -131,6 +131,13 @@ def add_columns_ndf(t : Tablo::Table)
   t
 end
 
+def add_columns_ndfs(t : Tablo::Table)
+  t.add_column("N") { |n| n[0] }
+  t.add_column("Double") { |n| n[0].as(Number) * 2 }
+  t.add_column("Triple", formatter: ->(val : Tablo::CellType) { "%.2f" % val }, styler: ->(val : Tablo::CellType) { "\e[31m#{val}\e[0m" }) { |n| n[0].as(Number) * 3 }
+  t
+end
+
 def add_columns_ndn(t : Tablo::Table)
   t.add_column("N") { |n| n[0] }
   t.add_column("Double") { |n| n[0].as(Number) * 2 }

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -616,6 +616,27 @@ describe "Tablo::Table" do
     end
     # <<<<< formatter parameter
 
+    # >>>>> styler parameter
+    describe "`styler` param" do
+      it "styles the formatted cell value for display, without affecting the width calculations" do
+        t13a = add_columns_ndfs(mktable_5i32(default_header_alignment: Tablo::Justify::Center))
+        t13a.to_s.should eq \
+          %(+--------------+--------------+--------------+
+         |       N      |    Double    |    Triple    |
+         +--------------+--------------+--------------+
+         |            1 |            2 |         \e[31m3.00\e[0m |
+         |            2 |            4 |         \e[31m6.00\e[0m |
+         |            3 |            6 |         \e[31m9.00\e[0m |
+         |            4 |            8 |        \e[31m12.00\e[0m |
+         |            5 |           10 |        \e[31m15.00\e[0m |
+         +--------------+--------------+--------------+).gsub(/^ +/m, "")
+        top_right_body_cell = t13a.first.to_a.last
+        top_right_body_cell.should eq(3)
+        top_right_body_cell.should be_a(Int32)
+      end
+    end
+    # <<<<< styler parameter
+
     # >>>>> extractor parameter
     describe "'extractor' parameter is mandatory and must be provided as a block" do
       t14a = add_columns_5n(mktable_5i32(default_header_alignment: Tablo::Justify::Center))

--- a/src/table.cr
+++ b/src/table.cr
@@ -56,6 +56,7 @@ module Tablo
     def add_column(label, header = nil, align_header = Justify::None,
                    align_body = Justify::None, width = nil,
                    formatter : CellType -> String = ->(n : CellType) { n.to_s },
+                   styler : CellType -> String = ->(n : CellType) { n.to_s },
                    &extractor : Array(CellType) -> CellType)
       if column_registry.has_key?(label)
         raise InvalidColumnLabelError.new("Column label already used in this table.")
@@ -67,6 +68,7 @@ module Tablo
         align_header,
         align_body,
         formatter,
+        styler,
         extractor
       )
     end


### PR DESCRIPTION
Adds a  `styler` option to add colors and other styling. See https://github.com/matt-harvey/tabulo#colours-and-other-styling- for inspiration.

Resolves https://github.com/hutou/tablo/issues/2

TODO: 

- [ ] add documentation to README